### PR TITLE
Fix the display message for Find Command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,6 +10,5 @@ public class Messages {
     public static final String MESSAGE_INVALID_APPLICATION_DISPLAYED_INDEX = "The application index provided is invalid";
     public static final String MESSAGE_EMPTY_LIST = "There is no application in your Internship list";
     public static final String MESSAGE_NO_MATCHING = "No matching result found in your Internship list";
-    public static final String MESSAGE_APPLICATION_LISTED_OVERVIEW = "%1$d application listed";
-
+    public static final String MESSAGE_APPLICATION_LISTED_OVERVIEW = "%1$d %2$s listed";
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -32,7 +32,8 @@ public class FindCommand extends Command {
         int listSize = model.getFilteredApplicationList().size();
         if (listSize == 0) return new CommandResult(Messages.MESSAGE_NO_MATCHING);
         return new CommandResult(
-                String.format(Messages.MESSAGE_APPLICATION_LISTED_OVERVIEW, model.getFilteredApplicationList().size()));
+                String.format(Messages.MESSAGE_APPLICATION_LISTED_OVERVIEW,
+                        listSize, listSize == 1 ? "application" : "applications"));
     }
 
     @Override


### PR DESCRIPTION
Fix a minor issue in the display message for find command -- when there is only a single match, the message is displayed in singular form (1 application found); when there are multiple matches, the message is displayed in plural form (n applications found)